### PR TITLE
Fix: Utilize `model` parameter in HFInferenceClientWorkflow

### DIFF
--- a/src/infernet_ml/workflows/inference/hf_inference_client_workflow.py
+++ b/src/infernet_ml/workflows/inference/hf_inference_client_workflow.py
@@ -103,7 +103,7 @@ class HFInferenceClientWorkflow(BaseInferenceWorkflow):
         """
         Setup the inference client
         """
-        self.client = InferenceClient(token=self.kwargs.get("token"))
+        self.client = InferenceClient(model=self.model_id, token=self.kwargs.get("token"))
         self.task = self.client.__getattribute__(self.task_id)
         self.task_argspec = inspect.getfullargspec(self.task)
         done = (


### PR DESCRIPTION
- Updated `do_setup` method in `HFInferenceClientWorkflow` to pass the `model` parameter to `InferenceClient`.
- Ensured the specified model is used for requests instead of the default model for the task.

This resolves the issue where the `model` parameter was not being used during initialization and setup.

Fixes #1